### PR TITLE
Add Store + Overlay board

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
           <a class="button" target="_blank" href="https://trello.com/b/Vqrkz3KO/android-beta-bugs"><i class="fab fa-android"></i> Android</a>
           <a class="button" target="_blank" href="https://trello.com/b/vLPlnX60/ios-testflight-bugs"><i class="fab fa-apple"></i> iOS</a>
           <a class="button" target="_blank" href="https://trello.com/b/UyU76Esh/linux-bugs"><i class="fab fa-linux"></i> Linux</a>
+          <a class="button" target="_blank" href="https://trello.com/b/Fb0LyRnD/store-bugs"><i class="fas fa-store-alt"></i> Store</a>
+          <a class="button" target="_blank" href="https://trello.com/b/k6jr4NyY/overlay-bugs"><i class="fas fa-window-restore"></i> Overlay</a>
         </div></li>
           <li>Screenshots/video may help explain your report and are required for visual bugs. You can post links to these in a client chat channel and ask for a <strong class="bh">Bug Hunter</strong> to attach them for you</li>
           <li>Bananas are an excellent source of potassium</li>


### PR DESCRIPTION
Added store + Overlay bug trello boards onto the top bar
If you would like to change the Overlay icon, please do, this seemed like a good icon based upon free Font-Awesome 5.20

![Desktop](https://puu.sh/DoIex/a583e90714.png)
![Mobile](https://puu.sh/DoIfw/84340782f3.png)