### PR TITLE
Adds Storeinfo page

### DIFF
--- a/css/bugreport.css
+++ b/css/bugreport.css
@@ -14,7 +14,7 @@ body {
 }
 
 body.light {
-    background-color: #fefefe; 
+    background-color: #fefefe;
     color: #0a0a0a;
 }
 
@@ -113,7 +113,7 @@ body.light .help-text {
 }
 
 .button-group a {
-    width: 5.6rem;
+    width: 6.2rem;
 }
 
 .button-group .button {
@@ -129,13 +129,13 @@ body.light .help-text {
 }
 
 @media screen and (max-width: 39.9375em) {
-    .trello > .button {
+    .workboards > .button {
         border-radius: 0.1875rem;
         width: 49%;
     }
 }
 
-.trello {
+.workboards {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
 }

--- a/edit.html
+++ b/edit.html
@@ -29,12 +29,14 @@
           <li class="menu-text">Unofficial Bug Syntax Tool</li>
           <li><a href="./"><i class="far fa-plus-square"></i></a></li>
           <li class="act-pg"><a href="./edit"><i class="far fa-edit"></i></a></li>
+          <li><a href="./storeinfo"><i class="fas fa-info"></i></a></li>
           <li><a id="switch-mobile"><i class="far fa-sun"></i></a></li>
         </ul>
         <ul class="menu show-for-medium">
           <li class="menu-text">Unofficial Bug Syntax Tool</li>
           <li><a href="./"><i class="far fa-plus-square"></i> Create</a></li>
           <li class="act-pg"><a href="./edit"><i class="far fa-edit"></i> Edit</a></li>
+          <li><a href="./storeinfo"><i class="fas fa-info"></i> Store Info</a></li>
         </ul>
       </div>
       <div class="top-bar-right show-for-medium">

--- a/index.html
+++ b/index.html
@@ -12,15 +12,6 @@
     <link rel="shortcut icon" href="images/favicon.ico" />
     <link rel="icon" type="image/png" href="images/favicon-192x192.png" sizes="192x192" />
     <link rel="apple-touch-icon" href="images/apple-touch-icon-180x180.png" sizes="180x180" />
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-101730653-1', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-    </script>
   </head>
   <body>
     <div class="top-bar">
@@ -50,16 +41,15 @@
       <div class="callout mbox">
         <strong>Remember:</strong>
         <ul>
-          <li>Check the Trello boards and/or bug report channels in case your bug has already been reported: <div class="small button-group trello">
-          <a class="button" target="_blank" href="https://trello.com/b/AExxR9lU/desktop-bugs"><i class="fas fa-desktop"></i> Desktop</a>
-          <a class="button" target="_blank" href="https://trello.com/b/Vqrkz3KO/android-beta-bugs"><i class="fab fa-android"></i> Android</a>
-          <a class="button" target="_blank" href="https://trello.com/b/vLPlnX60/ios-testflight-bugs"><i class="fab fa-apple"></i> iOS</a>
-          <a class="button" target="_blank" href="https://trello.com/b/UyU76Esh/linux-bugs"><i class="fab fa-linux"></i> Linux</a>
-          <a class="button" target="_blank" href="https://trello.com/b/Fb0LyRnD/store-bugs"><i class="fas fa-store-alt"></i> Store</a>
-          <a class="button" target="_blank" href="https://trello.com/b/k6jr4NyY/overlay-bugs"><i class="fas fa-window-restore"></i> Overlay</a>
+          <li>Check the Workboards and/or bug report channels in case your bug has already been reported: <div class="small button-group workboards">
+          <a class="button" target="_blank" href="https://bugs.discord.com/project/view/3/"><i class="fas fa-desktop"></i> Desktop</a>
+          <a class="button" target="_blank" href="https://bugs.discord.com/project/view/1/"><i class="fab fa-android"></i> Android</a>
+          <a class="button" target="_blank" href="https://bugs.discord.com/project/view/2/"><i class="fab fa-apple"></i> iOS</a>
+          <a class="button" target="_blank" href="https://bugs.discord.com/project/view/18/"><i class="fab fa-linux"></i> Linux</a>
+          <a class="button" target="_blank" href="https://bugs.discord.com/project/view/15/"><i class="fas fa-window-restore"></i> Overlay</a>
+          <a class="button" target="_blank" href="https://bugs.discord.com/project/view/14/"><i class="far fa-window-maximize"></i> Marketing</a>
         </div></li>
           <li>Screenshots/video may help explain your report and are required for visual bugs. You can post links to these in a client chat channel and ask for a <strong class="bh">Bug Hunter</strong> to attach them for you</li>
-          <li>Bananas are an excellent source of potassium</li>
         </ul>
       </div>
       <label for="desc-field">Short Description</label>
@@ -87,7 +77,7 @@
       <p class="help-text" id="client-help">The version/build of Discord you're using, e.g. TestFlight 1.9.2 <a data-open="client-ver-modal">(help)</a></p>
       <input type="text" id="client-field" aria-describedby="client-help" required>
       <label for="sys-field">System Settings</label>
-      <p class="help-text" id="sys-help">Your system settings including device model (if on mobile), OS, and version, e.g. iPhone 8, iOS 11.0.3</p>
+      <p class="help-text" id="sys-help">Your system settings including device model (if on mobile), OS, and version, e.g. iPhone 8, iOS 11.0.3<br><i>Use site's stored info here, in the same way as it's done on the bot with a -w for Windows</i></p>
       <input type="text" id="sys-field" aria-describedby="sys-help" required>
       <div class="callout warn hidden" id="lrg-rep">
         <p>Your report is quite large. Consider shortening it to ensure that it can be accepted by Bug Bot and Bug Hunters are able to approve/deny</p>
@@ -106,16 +96,15 @@
         <dd>
           <ul>
             <li>Open the Settings menu and scroll down</li>
-            <li>The version number should be listed at the bottom or next to the 'Change Log' entry</li>
-            <li>Also include if you're using a Testflight (inc. build number) or Alpha/Beta build</li>
+            <li>The <b>version number</b> should be listed at the bottom or next to the 'Change Log' entry</li>
+            <li>If you're on the TestFlight version of Discord, the <b>build number</b> is viewable in the TestFlight application</li>
           </ul>
         </dd>
         <dt>Desktop</dt>
         <dd>
           <ul>
-            <li>Open Dev Tools using <kbd>Ctrl+Shift+I</kbd> (Windows/Linux) or <kbd>Cmd+Opt+I</kbd> (macOS)</li>
-            <li>Click the Console tab</li>
-            <li>Scroll up and find the entry beginning '[BUILD INFO]'</li>
+            <li>Open Settings</li>
+            <li>The <b>version channel and number</b> are located at the bottom of the Left menu, below the 'Change Log' and Social Media icons.</li>
           </ul>
         </dd>
       </dl>
@@ -130,6 +119,13 @@
     <script>
       $(document).foundation();
       $(document).ready(pageLoad('create'));
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-145328931-1"></script>
+    <script>
+        window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}
+
+        gtag('js', new Date());
+        gtag('config', 'UA-145328931-1');
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,12 +29,14 @@
           <li class="menu-text">Unofficial Bug Syntax Tool</li>
           <li class="act-pg"><a href="./"><i class="far fa-plus-square"></i></a></li>
           <li><a href="./edit"><i class="far fa-edit"></i></a></li>
+          <li><a href="./storeinfo"><i class="fas fa-info"></i></a></li>
           <li><a id="switch-mobile"><i class="far fa-sun"></i></a></li>
         </ul>
         <ul class="menu show-for-medium">
           <li class="menu-text">Unofficial Bug Syntax Tool</li>
           <li class="act-pg"><a href="./"><i class="far fa-plus-square"></i> Create</a></li>
           <li><a href="./edit"><i class="far fa-edit"></i> Edit</a></li>
+          <li><a href="./storeinfo"><i class="fas fa-info"></i> Store Info</a></li>
         </ul>
       </div>
       <div class="top-bar-right show-for-medium">

--- a/js/bugreport.js
+++ b/js/bugreport.js
@@ -34,11 +34,11 @@ try {
 }
 if (!info) {
     info = {
-        "w": "",
-        "i": "",
-        "a": "",
-        "m": "",
-        "l": ""
+        'w': '',
+        'i': '',
+        'a': '',
+        'm': '',
+        'l': ''
     };
 }
 
@@ -59,7 +59,7 @@ function updateSyntax() {
     var actual = $('#act-field').val();
     var client = $('#client-field').val();
     var system = $('#sys-field').val();
-    var storeinfo = system.match(/(?:\B)-(l|m|w|a|i)(?:\b)/i);
+    var storeinfo = system.match(/(?:\B)-(w|m|l|a|i)(?:\b)/i);
     if (storeinfo && storeinfo[1]) {
         system = system.replace('-' + storeinfo[1], info[storeinfo[1]]);
     }
@@ -114,6 +114,12 @@ function updateEditSyntax() {
         }
     } else {
         edit_val = $('#' + edit_type + '-field').val();
+        if (edit_type == 'sys') {
+            var storeinfo = edit_val.match(/(?:\B)-(w|m|l|a|i)(?:\b)/i);
+            if (storeinfo && storeinfo[1]) {
+                edit_val = edit_val.replace('-' + storeinfo[1], info[storeinfo[1]]);
+            }
+        }
         alias = field_data[edit_type].al;
     }
     var edit_txt = '';
@@ -204,7 +210,7 @@ function pageLoad(page) {
             $('input[id*="-info"]').each(function(i, item) {
                 var device = item.id.substring(0,1);
                 item.value = info[device];
-            })
+            });
             break;
     }
     if (cb_btn !== '' && st !== '') {

--- a/js/bugreport.js
+++ b/js/bugreport.js
@@ -2,27 +2,27 @@ var field_data = {
     desc: {
         fn: "Short Description",
         ht: "Describe your bug in a single sentence",
-        al: "title"
+        al: "-t"
     },
     exp: {
         fn: "Expected Result",
         ht: "What *should* happen when following the steps? (i.e. if the bug didn't occur)",
-        al: "expected"
+        al: "-e"
     },
     act: {
         fn: "Actual Result",
         ht: "What *actually* happens when following the steps?",
-        al: "actual"
+        al: "-a"
     },
     client: {
         fn: "Client Version",
         ht: "The version/build of Discord you're using, e.g. TestFlight 1.9.2",
-        al: "cs"
+        al: "-c"
     },
     sys: {
         fn: "System Settings",
         ht: "Your system settings including device model (if on mobile), OS, and version, e.g. iPhone 8, iOS 11.0.3",
-        al: "ss"
+        al: "-s"
     }
 };
 var info = false;
@@ -73,16 +73,22 @@ function updateSyntax() {
     if (storeinfo && storeinfo[1]) {
         system = system.replace('-' + storeinfo[1], info[storeinfo[1]]);
     }
+
     var steps = '';
     var bugtext = '';
     for (var i = 1; i <= window.sct; i++) {
         var step = $('#s' + i + '-field').val();
         if (step) {
-            steps = steps + ' - ' + step;
+            if (steps == "") {
+                steps = step;
+            } else {
+                steps = steps + ' ~ ' + step;
+            }
         }
+
     }
     if (desc && expected && actual && client && system && steps) {
-        bugtext = '!submit ' + desc + ' | Steps to Reproduce:' + steps + ' Expected Result: ' + expected + ' Actual Result: ' + actual + ' Client Settings: ' + client + ' System Settings: ' + system;
+        bugtext = '!submit -t ' + desc + ' -r ' + steps + ' -e ' + expected + ' -a ' + actual + ' -c ' + client + ' -s ' + system;
     }
     $('#syntax').text(bugtext);
     $('#lrg-rep').toggleClass('hidden', bugtext.length < 1400);
@@ -112,15 +118,16 @@ function updateEditSyntax() {
     var edit_val = '';
     var alias = '';
     if (edit_type == 'steps') {
-        alias = 'str';
+        alias = '-r';
         for (var i = 1; i <= window.sct; i++) {
             var step = $('#s' + i + '-field').val();
             if (step) {
-                edit_val = edit_val + ' - ' + step;
+                if (edit_val == "") { // Fixes issue with first step not using a ~
+                    edit_val = step;
+                } else {
+                    edit_val = edit_val + ' ~ ' + step;
+                }
             }
-        }
-        if (edit_val) {
-            edit_val = edit_val.substr(1);
         }
     } else {
         edit_val = $('#' + edit_type + '-field').val();
@@ -134,7 +141,7 @@ function updateEditSyntax() {
     }
     var edit_txt = '';
     if (edit_id && edit_val) {
-        edit_txt = '!edit ' + edit_id + ' | ' + alias + ' | ' + edit_val;
+        edit_txt = '!edit ' + edit_id + ' ' + alias + ' ' + edit_val;
     }
     $('#edit-syntax').text(edit_txt);
 }
@@ -145,7 +152,7 @@ function updateField(event) {
     $('#add-btn').off('click');
     $('#del-btn').off('click');
     switch(event.target.value) {
-        case "steps":            
+        case "steps":
             var steps_html = '<label>Steps to Reproduce</label><p class="help-text" id="steps-help">Write each step others would have to follow to reproduce the bug. Note: Dashes will be added automatically for each step. To add/remove fields, you can use the buttons below</p><div class="callout mbox" id="steps-fs"><div class="button-group small"><button type="button" class="button" id="add-btn"><i class="fas fa-plus"></i> Add</button><button type="button" class="button" id="del-btn"><i class="fas fa-minus"></i> Remove</button></div><div class="input-group" id="s1-grp"><span class="input-group-label">Step 1</span><input type="text" class="input-group-field" id="s1-field" required></div></div>';
             $('#edit-field').html(steps_html);
             $('#add-btn').on('click', addStep);

--- a/js/bugreport.js
+++ b/js/bugreport.js
@@ -58,8 +58,8 @@ function infoload() {
         var device = item.id.substring(0,1);
         item.value = info[device];
     });
-    if (typeof(Storage) !== 'undefined') {
-        alert('This web browser does no support localstorage. Store info will not function!');
+    if (typeof(Storage) === 'undefined') {
+        alert('This web browser does not support localStorage. Store info will not function!');
     }
 }
 

--- a/js/bugreport.js
+++ b/js/bugreport.js
@@ -26,6 +26,22 @@ var field_data = {
     }
 };
 
+var info = localStorage.getItem('storeinfo');
+try {
+    info = JSON.parse(info);
+} catch (e) {
+    info = false;
+}
+if (!info) {
+    info = {
+        "w": "",
+        "i": "",
+        "a": "",
+        "m": "",
+        "l": ""
+    };
+}
+
 var mm = {
     dark: {
         d: "Light Mode",
@@ -43,6 +59,10 @@ function updateSyntax() {
     var actual = $('#act-field').val();
     var client = $('#client-field').val();
     var system = $('#sys-field').val();
+    var storeinfo = system.match(/(?:\B)-(l|m|w|a|i)(?:\b)/i);
+    if (storeinfo && storeinfo[1]) {
+        system = system.replace('-' + storeinfo[1], info[storeinfo[1]]);
+    }
     var steps = '';
     var bugtext = '';
     for (var i = 1; i <= window.sct; i++) {
@@ -123,6 +143,14 @@ function updateField(event) {
     }
 }
 
+function updateInfo() {
+    $('input[id*="-info"]').each(function(i, item) {
+        var device = item.id.substring(0,1);
+        info[device] = item.value;
+    });
+    localStorage.setItem('storeinfo', JSON.stringify(info));
+}
+
 function loadTheme() {
     var light = false;
     if (typeof(Storage) !== 'undefined') {
@@ -171,19 +199,28 @@ function pageLoad(page) {
             cb_btn = '#edit-copy-btn';
             st = '#edit-syntax';
             break;
+        case "storeinfo":
+            $('div#content').on('blur', 'input[id*="-info"]', updateInfo);
+            $('input[id*="-info"]').each(function(i, item) {
+                var device = item.id.substring(0,1);
+                item.value = info[device];
+            })
+            break;
     }
-    var cb = new ClipboardJS(cb_btn, {
-        text: function(trigger) {
-            return $(st).text();
-        }
-    });
-    cb.on('success', function(e) {
-        $(e.trigger).html('Copied');
-        ga('send', 'event', 'syntax', 'copy');
-        setTimeout(function() {
-            $(e.trigger).html('Copy');
-        }, 2000);
-    });
+    if (cb_btn !== '' && st !== '') {
+        var cb = new ClipboardJS(cb_btn, {
+            text: function(trigger) {
+                return $(st).text();
+            }
+        });
+        cb.on('success', function(e) {
+            $(e.trigger).html('Copied');
+            ga('send', 'event', 'syntax', 'copy');
+            setTimeout(function() {
+                $(e.trigger).html('Copy');
+            }, 2000);
+        });
+    }
     $('body').on('click', 'a[id*="switch-"]', switchMode);
     if (loadTheme()) {
         switchMode();

--- a/js/bugreport.js
+++ b/js/bugreport.js
@@ -25,13 +25,13 @@ var field_data = {
         al: "ss"
     }
 };
-
-var info = localStorage.getItem('storeinfo');
-try {
-    info = JSON.parse(info);
-} catch (e) {
-    info = false;
+var info = false;
+if (typeof(Storage) !== 'undefined') {
+    info = localStorage.getItem('storeinfo');
+    try       { info = JSON.parse(info); }
+    catch (e) { }
 }
+
 if (!info) {
     info = {
         "w": "",
@@ -52,6 +52,16 @@ var mm = {
         m: "moon"
     }
 };
+
+function infoload() {
+    $('input[id*="-info"]').each(function(i, item) {
+        var device = item.id.substring(0,1);
+        item.value = info[device];
+    });
+    if (typeof(Storage) !== 'undefined') {
+        alert('This web browser does no support localstorage. Store info will not function!');
+    }
+}
 
 function updateSyntax() {
     var desc = $('#desc-field').val();
@@ -144,11 +154,13 @@ function updateField(event) {
 }
 
 function updateInfo() {
-    $('input[id*="-info"]').each(function(i, item) {
-        var device = item.id.substring(0,1);
-        info[device] = item.value;
-    });
-    localStorage.setItem('storeinfo', JSON.stringify(info));
+    if (typeof(Storage) !== 'undefined') {
+        $('input[id*="-info"]').each(function(i, item) {
+            var device = item.id.substring(0,1);
+            info[device] = item.value;
+        });
+        localStorage.setItem('storeinfo', JSON.stringify(info));
+    }
 }
 
 function loadTheme() {
@@ -200,11 +212,8 @@ function pageLoad(page) {
             st = '#edit-syntax';
             break;
         case "storeinfo":
+            infoload();
             $('div#content').on('blur', 'input[id*="-info"]', updateInfo);
-            $('input[id*="-info"]').each(function(i, item) {
-                var device = item.id.substring(0,1);
-                item.value = info[device];
-            })
             break;
     }
     if (cb_btn !== '' && st !== '') {

--- a/storeinfo.html
+++ b/storeinfo.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Unofficial Discord Bug Syntax Tool</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.3.1/css/foundation.min.css" integrity="sha256-itWEYdFWzZPBG78bJOOiQIn06QCgN/F0wMDcC4nOhxY=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous" />
+    <link rel="stylesheet" type="text/css" href="css/bugreport.css" />
+    <link rel="shortcut icon" href="images/favicon.ico" />
+    <link rel="icon" type="image/png" href="images/favicon-192x192.png" sizes="192x192" />
+    <link rel="apple-touch-icon" href="images/apple-touch-icon-180x180.png" sizes="180x180" />
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-101730653-1', 'auto');
+      ga('set', 'anonymizeIp', true);
+      ga('send', 'pageview');
+    </script>
+  </head>
+  <body>
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="menu show-for-small-only">
+          <li class="menu-text">Unofficial Bug Syntax Tool</li>
+          <li><a href="./"><i class="far fa-plus-square"></i></a></li>
+          <li><a href="./edit"><i class="far fa-edit"></i></a></li>
+          <li class="act-pg"><a href="./storeinfo"><i class="fas fa-info"></i></a></li>
+          <li><a id="switch-mobile"><i class="far fa-sun"></i></a></li>
+        </ul>
+        <ul class="menu show-for-medium">
+          <li class="menu-text">Unofficial Bug Syntax Tool</li>
+          <li><a href="./"><i class="far fa-plus-square"></i> Create</a></li>
+          <li><a href="./edit"><i class="far fa-edit"></i> Edit</a></li>
+          <li class="act-pg"><a href="./storeinfo"><i class="fas fa-info"></i> Store Info</a></li>
+        </ul>
+      </div>
+      <div class="top-bar-right show-for-medium">
+        <ul class="menu">
+          <li><a id="switch-desktop"><i class="far fa-sun"></i> Light Mode</a></li>
+        </ul>
+      </div>
+    </div><br />
+    <div class="column row" id="content">
+      <h5>Store Info</h5>
+      <div class="callout mbox">
+        <strong>Notice:</strong>
+        <p class="help-text">Information is stored locally to your Device and not on any of our servers.</p>
+      </div>
+      
+      <label for="windows-info">Windows Information</label>
+      <p class="help-text" id="windows-help">This is the Windows and version you are running. Example: Windows 10 64x, Version 1903. <a data-open="win-ver-modal">(help)</a></p>
+      <input type="text" id="windows-info" aria-describedby="windows-help">
+
+      <label for="mac-info">Mac Information</label>
+      <p class="help-text" id="mac-help">This is the Mac computer and version you are running. Example: Early 2015 Macbook Pro Retina, macOS Sierra 10.12.6. <a data-open="mac-ver-modal">(help)</a></p>
+      <input type="text" id="mac-info" aria-describedby="mac-help">
+
+      <label for="linux-info">Linux Information</label>
+      <p class="help-text" id="linux-help">This is the Linux distro and version you are running. Example: Ubuntu 18.04. <a data-open="linux-ver-modal">(help)</a></p>
+      <input type="text" id="linux-info" aria-describedby="linux-help">
+
+      <label for="android-info">Android Information</label>
+      <p class="help-text" id="android-help">This is the Phone you are running, and the Android version you are running. Example: Pixel 3, Android 9. <a data-open="android-ver-modal">(help)</a></p>
+      <input type="text" id="android-info" aria-describedby="android-help">
+
+      <label for="ios-info">iOS Information</label>
+      <p class="help-text" id="ios-help">This is the Device you are running, and the iOS version you are running. Example: iPhone XR iOS 12.3.1. <a data-open="ios-ver-modal">(help)</a></p>
+      <input type="text" id="ios-info" aria-describedby="ios-help">
+
+    </div>
+    <!-- End of main Content -->
+    
+    <div class="reveal" id="win-ver-modal" data-reveal>
+        <h4>Finding your Microsoft Windows Version</h4>
+        <dl>
+            <dt>Both</dt>
+            <dd>
+              <ul>
+                <li>Press the Windows logo key + R.</li>
+                <li>Type <code>winver</code> in the Open box, and then select OK.</li>
+                <li>At the top will show which Windows you are running, and the second line of the body will show the Version you are running.</li>
+              </ul>
+            </dd>
+          <dt>Windows 10</dt>
+          <dd>
+            <ul>
+              <li>Open the Start menu, Settings, System, About. Alternatively you can click <a href="ms-settings:about">here</a> to open it directly.</li>
+              <li>Scroll down to Windows Specification.</li>
+              <li><strong>Edition</strong> is the Windows you are running and <strong>Version</strong> is the version of Windows you are running on.</li>
+            </ul>
+          </dd>
+          <dt>Windows 8</dt>
+          <dd>
+            <ul>
+              <li>If you're using a <strong>touch device</strong>, swipe in from the right edge of the screen, tap Settings, and then tap Change PC settings. Continue to step 3.</li>
+              <li>If you're using a <strong>mouse</strong>, point to the lower-right corner of the screen, move the mouse pointer up, click Settings, and then click Change PC settings.</li>
+              <li>Select PC and devices, PC info.</li>
+              <li>Under the Windows Header you will see the Edition of Windows you are running.</li>
+            </ul>
+          </dd>
+        </dl>
+        <button type="button" class="close-button" data-close aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <div class="reveal" id="mac-ver-modal" data-reveal>
+        <h4>Finding your Mac Version</h4>
+        <dl>
+          <dt>TITLE</dt>
+          <dd>
+            <ul>
+              <li>INFO</li>
+              <li>MORE INFO</li>
+              <li>LITTLE BIT MORE</li>
+            </ul>
+          </dd>
+        </dl>
+        <button type="button" class="close-button" data-close aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <div class="reveal" id="linux-ver-modal" data-reveal>
+        <h4>Finding your Linux Version</h4>
+        <dl>
+          <dt>TITLE</dt>
+          <dd>
+            <ul>
+              <li>INFO</li>
+              <li>MORE INFO</li>
+              <li>LITTLE BIT MORE</li>
+            </ul>
+          </dd>
+        </dl>
+        <button type="button" class="close-button" data-close aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <div class="reveal" id="android-ver-modal" data-reveal>
+        <h4>Finding your Android Version</h4>
+        <dl>
+          <dt>TITLE</dt>
+          <dd>
+            <ul>
+              <li>INFO</li>
+              <li>MORE INFO</li>
+              <li>LITTLE BIT MORE</li>
+            </ul>
+          </dd>
+        </dl>
+        <button type="button" class="close-button" data-close aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <div class="reveal" id="ios-ver-modal" data-reveal>
+        <h4>Finding your iOS Version</h4>
+        <dl>
+          <dt>TITLE</dt>
+          <dd>
+            <ul>
+              <li>INFO</li>
+              <li>MORE INFO</li>
+              <li>LITTLE BIT MORE</li>
+            </ul>
+          </dd>
+        </dl>
+        <button type="button" class="close-button" data-close aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.3.1/js/foundation.min.js" integrity="sha256-Nd2xznOkrE9HkrAMi4xWy/hXkQraXioBg9iYsBrcFrs=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.1/clipboard.min.js"></script>
+    <script src="js/bugreport.js"></script>
+    <script>
+      $(document).foundation();
+      $(document).ready(pageLoad('storeinfo'));
+    </script>
+  </body>
+</html>

--- a/storeinfo.html
+++ b/storeinfo.html
@@ -57,11 +57,11 @@
       <input type="text" id="windows-info" aria-describedby="windows-help">
 
       <label for="mac-info">Mac Information</label>
-      <p class="help-text" id="mac-help">This is the Mac computer and version you are running. Example: Early 2015 Macbook Pro Retina, macOS Sierra 10.12.6. <a data-open="mac-ver-modal">(help)</a></p>
+      <p class="help-text" id="mac-help">This is the Mac computer and version you are running. Example: Early 2015 Macbook Pro Retina, macOS Sierra 10.12.6. <!--<a data-open="mac-ver-modal">(help)</a>--></p>
       <input type="text" id="mac-info" aria-describedby="mac-help">
 
       <label for="linux-info">Linux Information</label>
-      <p class="help-text" id="linux-help">This is the Linux distro and version you are running. Example: Ubuntu 18.04. <a data-open="linux-ver-modal">(help)</a></p>
+      <p class="help-text" id="linux-help">This is the Linux distro and version you are running. Example: Ubuntu 18.04. <!--<a data-open="linux-ver-modal">(help)</a>--></p>
       <input type="text" id="linux-info" aria-describedby="linux-help">
 
       <label for="android-info">Android Information</label>
@@ -69,19 +69,19 @@
       <input type="text" id="android-info" aria-describedby="android-help">
 
       <label for="ios-info">iOS Information</label>
-      <p class="help-text" id="ios-help">This is the Device you are running, and the iOS version you are running. Example: iPhone XR iOS 12.3.1. <a data-open="ios-ver-modal">(help)</a></p>
+      <p class="help-text" id="ios-help">This is the Device you are running, and the iOS version you are running. Example: iPhone XR iOS 12.3.1. <!--<a data-open="ios-ver-modal">(help)</a>--></p>
       <input type="text" id="ios-info" aria-describedby="ios-help">
 
     </div>
     <!-- End of main Content -->
-    
+
     <div class="reveal" id="win-ver-modal" data-reveal>
         <h4>Finding your Microsoft Windows Version</h4>
         <dl>
             <dt>Both</dt>
             <dd>
               <ul>
-                <li>Press the Windows logo key + R.</li>
+                <li>Press the <i class="fab fa-windows"></i> Windows logo key + R.</li>
                 <li>Type <code>winver</code> in the Open box, and then select OK.</li>
                 <li>At the top will show which Windows you are running, and the second line of the body will show the Version you are running.</li>
               </ul>
@@ -89,7 +89,7 @@
           <dt>Windows 10</dt>
           <dd>
             <ul>
-              <li>Open the Start menu, Settings, System, About. Alternatively you can click <a href="ms-settings:about">here</a> to open it directly.</li>
+              <li>Open the Start menu, <i class="fas fa-cog"></i> Settings, System, About. Alternatively you can click <a href="ms-settings:about">here</a> to open it directly.</li>
               <li>Scroll down to Windows Specification.</li>
               <li><strong>Edition</strong> is the Windows you are running and <strong>Version</strong> is the version of Windows you are running on.</li>
             </ul>
@@ -97,8 +97,8 @@
           <dt>Windows 8</dt>
           <dd>
             <ul>
-              <li>If you're using a <strong>touch device</strong>, swipe in from the right edge of the screen, tap Settings, and then tap Change PC settings. Continue to step 3.</li>
-              <li>If you're using a <strong>mouse</strong>, point to the lower-right corner of the screen, move the mouse pointer up, click Settings, and then click Change PC settings.</li>
+              <li>If you're using a <strong>touch device</strong>, swipe in from the right edge of the screen, tap <i class="fas fa-cog"></i> Settings, and then tap Change PC settings. Continue to step 3.</li>
+              <li>If you're using a <strong>mouse</strong>, point to the lower-right corner of the screen, move the mouse pointer up, click <i class="fas fa-cog"></i> Settings, and then click Change PC settings.</li>
               <li>Select PC and devices, PC info.</li>
               <li>Under the Windows Header you will see the Edition of Windows you are running.</li>
             </ul>
@@ -146,12 +146,13 @@
     <div class="reveal" id="android-ver-modal" data-reveal>
         <h4>Finding your Android Version</h4>
         <dl>
-          <dt>TITLE</dt>
+          <dt>All </dt>
           <dd>
             <ul>
-              <li>INFO</li>
-              <li>MORE INFO</li>
-              <li>LITTLE BIT MORE</li>
+              <li>Open <i class="fas fa-cog"></i> Settings app.</li>
+              <li>Scroll down to the bottom and Select <strong>About Phone</strong>.</li>
+              <li>On some devices you will need to click an additional menu of Software Info.</li>
+              <li>There should be an item called Android Version.</li>
             </ul>
           </dd>
         </dl>

--- a/storeinfo.html
+++ b/storeinfo.html
@@ -170,7 +170,7 @@
             <ul>
               <li>Go to Settings > General.</li>
               <li>Then tap About</li>
-              <li>In the menu you will have Modal Name + Software Version</li>
+              <li>In the menu you will have Model Name + Software Version</li>
             </ul>
           </dd>
         </dl>

--- a/storeinfo.html
+++ b/storeinfo.html
@@ -51,25 +51,25 @@
         <strong>Notice:</strong>
         <p class="help-text">Information is stored locally to your Device and not on any of our servers.</p>
       </div>
-      
+
       <label for="windows-info">Windows Information</label>
-      <p class="help-text" id="windows-help">This is the Windows and version you are running. Example: Windows 10 64x, Version 1903. <a data-open="win-ver-modal">(help)</a></p>
+      <p class="help-text" id="windows-help">This is the Windows and version you are running. <a data-open="win-ver-modal">(help)</a><br><em>Example: Windows 10 64x, Version 1903.</em></p>
       <input type="text" id="windows-info" aria-describedby="windows-help">
 
       <label for="mac-info">Mac Information</label>
-      <p class="help-text" id="mac-help">This is the Mac computer and version you are running. Example: Early 2015 Macbook Pro Retina, macOS Sierra 10.12.6. <!--<a data-open="mac-ver-modal">(help)</a>--></p>
+      <p class="help-text" id="mac-help">This is the Mac computer and version you are running. <a data-open="mac-ver-modal">(help)</a><br><em>Example: Early 2015 Macbook Pro Retina, macOS Sierra 10.12.6.</em></p>
       <input type="text" id="mac-info" aria-describedby="mac-help">
 
       <label for="linux-info">Linux Information</label>
-      <p class="help-text" id="linux-help">This is the Linux distro and version you are running. Example: Ubuntu 18.04. <!--<a data-open="linux-ver-modal">(help)</a>--></p>
+      <p class="help-text" id="linux-help">This is the Linux distro and version you are running. <a data-open="linux-ver-modal">(help)</a><br><em>Example: Ubuntu 18.04.</em></p>
       <input type="text" id="linux-info" aria-describedby="linux-help">
 
       <label for="android-info">Android Information</label>
-      <p class="help-text" id="android-help">This is the Phone you are running, and the Android version you are running. Example: Pixel 3, Android 9. <a data-open="android-ver-modal">(help)</a></p>
+      <p class="help-text" id="android-help">This is the Phone you are running, and the Android version you are running. <a data-open="android-ver-modal">(help)</a><br><em>Example: Pixel 3, Android 9.</em></p>
       <input type="text" id="android-info" aria-describedby="android-help">
 
       <label for="ios-info">iOS Information</label>
-      <p class="help-text" id="ios-help">This is the Device you are running, and the iOS version you are running. Example: iPhone XR iOS 12.3.1. <!--<a data-open="ios-ver-modal">(help)</a>--></p>
+      <p class="help-text" id="ios-help">This is the Device you are running, and the iOS version you are running. <a data-open="ios-ver-modal">(help)</a><br><em>Example: iPhone XR iOS 12.3.1.</em></p>
       <input type="text" id="ios-info" aria-describedby="ios-help">
 
     </div>
@@ -112,12 +112,13 @@
     <div class="reveal" id="mac-ver-modal" data-reveal>
         <h4>Finding your Mac Version</h4>
         <dl>
-          <dt>TITLE</dt>
+          <dt>All versions</dt>
           <dd>
             <ul>
-              <li>INFO</li>
-              <li>MORE INFO</li>
-              <li>LITTLE BIT MORE</li>
+              <li>Choose Apple menu in the top left of your Screen</li>
+              <li>Select the <strong>About This Mac</strong></li>
+              <li>At the top will say the Version of macOS you are running.</li>
+              <li>On the First line below the version will tell you the Specific mac you are using!</li>
             </ul>
           </dd>
         </dl>
@@ -129,12 +130,12 @@
     <div class="reveal" id="linux-ver-modal" data-reveal>
         <h4>Finding your Linux Version</h4>
         <dl>
-          <dt>TITLE</dt>
+          <dt>Most Linux Versions</dt>
           <dd>
             <ul>
-              <li>INFO</li>
-              <li>MORE INFO</li>
-              <li>LITTLE BIT MORE</li>
+              <li>Open a new Command line interface</li>
+              <li>Type in the following command: <code>lsb_release -a</code></li>
+              <li>and you can use the Description field.</li>
             </ul>
           </dd>
         </dl>
@@ -164,12 +165,12 @@
     <div class="reveal" id="ios-ver-modal" data-reveal>
         <h4>Finding your iOS Version</h4>
         <dl>
-          <dt>TITLE</dt>
+          <dt>All iOS Versions</dt>
           <dd>
             <ul>
-              <li>INFO</li>
-              <li>MORE INFO</li>
-              <li>LITTLE BIT MORE</li>
+              <li>Go to Settings > General.</li>
+              <li>Then tap About</li>
+              <li>In the menu you will have Modal Name + Software Version</li>
             </ul>
           </dd>
         </dl>


### PR DESCRIPTION
A new page to store info similar to how Bug Bot does on DTesters already.
![Example](https://i.imgur.com/jOIPLV2.png)

**Usage:**
- Open store info page
- Fill in boxes for System settings
- When creating a bug users can use the normal `-w` or `-a` to fill in their info into the command.
    OR
    Use the edit command for System settings.


**Uncompleted:**
- Linux, Mac and iOS collection of system settings.
    This is mainly due to the lack of owning any of these. The modal and the "Help" button all exist, but are commented out/inaccessable.